### PR TITLE
Add project for .net 6.0

### DIFF
--- a/geometry3Sharp_net_netstd.csproj
+++ b/geometry3Sharp_net_netstd.csproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Version>1.0.0.0</Version>
+	<Title>geometry3Sharp</Title>
+    <Authors>Ryan Schmidt</Authors>
+    <Company>gradientspace</Company>
+    <Description>C# library for 2D/3D geometric computing and triangle mesh processing</Description>
+    <Copyright>Copyright © Ryan Schmidt 2016</Copyright>
+    <PackageLicenseUrl>https://github.com/gradientspace/geometry3Sharp/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/gradientspace/geometry3Sharp</PackageProjectUrl>
+    <PackageTags>geometry3;graphics;math;approximation;solvers;color;convexhull;meshes;spatial;curves;solids;3d;unity</PackageTags>
+	<RepositoryUrl>https://github.com/gradientspace/geometry3Sharp</RepositoryUrl>
+	<RepositoryType>git</RepositoryType>
+	<TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <RootNamespace>g3</RootNamespace>
+    <AssemblyName>geometry3Sharp</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Product>geometry3Sharp</Product>
+    <PackageId>geometry3Sharp</PackageId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
- Allow dependent projects to use .net 6.0 for advanced features.
